### PR TITLE
张谊旺-20181121-跟新了问题8,9,10,12,13,17,18

### DIFF
--- a/templates/admin/import_export/change_list_import_item.html
+++ b/templates/admin/import_export/change_list_import_item.html
@@ -2,6 +2,8 @@
 {% load admin_urls %}
 {% if opts.model_name == "sampleinfoform"  %}
 {#<li><a href='{% url opts|admin_urlname:"import" %}' class="import_link">{% trans "Import" %}</a></li>#}
+    {% elif opts.model_name == "subproject" %}
+    <!--<li><a href='{% url opts|admin_urlname:"import" %}' class="import_link">{% trans "Import" %}</a></li>-->
     {% else %}
     <li><a href='{% url opts|admin_urlname:"import" %}' class="import_link">{% trans "Import" %}</a></li>
 {% endif %}


### PR DESCRIPTION
去掉多余合同号
问题8：样品显示数量
问题9：子项目编号增加日期
问题10：测序页面美观度改进
问题12：分析列表不显示刚才创建的分析任务
问题13：立项里去掉导入，改成动作。
问题17：超级管理员的：提取，建库。测序，分析任务下单，进不去。
问题18：销售总监只保留导出动作。改成只有项目管理组之外都不能启动中止项目。
